### PR TITLE
Die if player is under the camera

### DIFF
--- a/game/src/Actors/Player.gd
+++ b/game/src/Actors/Player.gd
@@ -20,6 +20,7 @@ func _physics_process(delta: float) -> void:
 	_velocity = move_and_slide_with_snap(
 		_velocity, snap, FLOOR_NORMAL, true
 	)
+	die() if $".".position.y > 1080.0 else ""
 
 
 func get_direction() -> Vector2:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [ ] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
One Line in `Player.gd` which checks a thing.


**Does this PR introduce a breaking change?**
Not really. It's just a small improvement.


## New feature or change ##


**What is the current behavior?** 
If Player is falling under the world (`TileMap`) the Player is falling and falling. The User just can move from left to right or pause the game.


**What is the new behavior?**
The Player dies if it's under 1080 y-Axis.


**Other information**
![Example Image](https://user-images.githubusercontent.com/58821401/96975587-ef1e3780-151a-11eb-8528-7b7b5451e0b2.png)
_(The Ruler is at the location, when player is dieing)_
